### PR TITLE
backend backlinks completed, UX WIP but working

### DIFF
--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -25,7 +25,7 @@
     "@holochain-syn/client": "^0.0.4",
     "@holochain-syn/elements": "^0.0.6",
     "@holochain-syn/store": "^0.0.5",
-    "@holochain-syn/text-editor": "^0.0.8",
+    "@holochain-syn/text-editor": "^0.0.10",
     "@holochain/client": "^0.4.1",
     "@open-wc/scoped-elements": "^2.0.1",
     "@scoped-elements/markdown-renderer": "^0.0.3",

--- a/libs/ui/src/elements/markdown-note.ts
+++ b/libs/ui/src/elements/markdown-note.ts
@@ -18,6 +18,8 @@ import {
   Fab,
   Snackbar,
   MenuSurface,
+  List,
+  ListItem,
 } from '@scoped-elements/material-web';
 
 import { notesStoreContext } from '../context';
@@ -25,6 +27,7 @@ import { NotesStore, NoteSynStore } from '../notes-store';
 import { sharedStyles } from '../shared-styles';
 
 import { getLatestCommit } from './utils';
+import { NoteWithBacklinks } from '../types';
 
 export class MarkdownNote extends ScopedElementsMixin(LitElement) {
   @property()
@@ -45,6 +48,10 @@ export class MarkdownNote extends ScopedElementsMixin(LitElement) {
     this,
     () => this._activeSession.value?.lastCommitHash
   );
+
+  _myNoteTitles = new StoreSubscriber(this, () => this._notesStore.notesCreatedByMe);
+
+  _othersNoteTitles = new StoreSubscriber(this, () => this._notesStore.notesCreatedByOthers);
 
   _state = new StoreSubscriber(this, () => this._activeSession.value?.state);
 
@@ -209,15 +216,18 @@ export class MarkdownNote extends ScopedElementsMixin(LitElement) {
             if (text[position - 1] === '[' && text[position] === ']') {
               console.log('square bracket activated')
               const menuSurface  = this.shadowRoot?.getElementById("title-search-modal") as MenuSurface;
-              // menuSurface.x = e.detail.coords.x;
-              // menuSurface.y = e.detail.coords.y;
+              menuSurface.x = e.detail.coords.left + 20;
+              menuSurface.y = e.detail.coords.top + 20;
               menuSurface.show()
             }
           }}
           }
       ></syn-text-editor>
-      <mwc-menu-surface fixed id="title-search-modal">
-          surface
+      <mwc-menu-surface relative id="title-search-modal">
+          <mwc-list>
+            ${Object.values(this._myNoteTitles.value).map((note: NoteWithBacklinks) => html`<mwc-list-item>${note.title}</mwc-list-item>`)}
+            ${Object.values(this._othersNoteTitles.value).map((note: NoteWithBacklinks) => html`<mwc-list-item>${note.title}</mwc-list-item>`)}
+          </mwc-list>
       </mwc-menu-surface>
 
       <mwc-card style="flex: 1; margin-left: 4px;">
@@ -310,6 +320,8 @@ export class MarkdownNote extends ScopedElementsMixin(LitElement) {
       'syn-commit-history': SynCommitHistory,
       'syn-context': SynContext,
       'mwc-menu-surface': MenuSurface,
+      'mwc-list': List,
+      'mwc-list-item': ListItem,
     };
   }
 

--- a/libs/ui/src/elements/markdown-note.ts
+++ b/libs/ui/src/elements/markdown-note.ts
@@ -9,7 +9,7 @@ import {
   SynCommitHistory,
   SynSessions,
 } from '@holochain-syn/elements';
-import { SynTextEditor } from '@holochain-syn/text-editor';
+import { SynTextEditor, TextEditorDeltaType } from '@holochain-syn/text-editor';
 import { StoreSubscriber } from 'lit-svelte-stores';
 import { MarkdownRenderer } from '@scoped-elements/markdown-renderer';
 import {
@@ -17,6 +17,7 @@ import {
   CircularProgress,
   Fab,
   Snackbar,
+  MenuSurface,
 } from '@scoped-elements/material-web';
 
 import { notesStoreContext } from '../context';
@@ -57,6 +58,9 @@ export class MarkdownNote extends ScopedElementsMixin(LitElement) {
 
   @state()
   _fetchingSnapshot = false;
+
+  @state()
+  _noteLinkModalOpen = false;
 
   _selectedCommitHash: EntryHashB64 | undefined;
 
@@ -197,7 +201,24 @@ export class MarkdownNote extends ScopedElementsMixin(LitElement) {
       <syn-text-editor
         style="flex: 1;"
         .synSlice=${this._activeSession.value}
+        @text-inserted=${(e: any) => {
+          if (e.detail.text === '[]') {
+            this._activeSession.value?.requestChanges([{type: TextEditorDeltaType.ChangeSelection, position: e.detail.from + 1, characterCount: 0}])
+            const text = this._state.value?.text;
+            const position = e.detail.from;
+            if (text[position - 1] === '[' && text[position] === ']') {
+              console.log('square bracket activated')
+              const menuSurface  = this.shadowRoot?.getElementById("title-search-modal") as MenuSurface;
+              // menuSurface.x = e.detail.coords.x;
+              // menuSurface.y = e.detail.coords.y;
+              menuSurface.show()
+            }
+          }}
+          }
       ></syn-text-editor>
+      <mwc-menu-surface fixed id="title-search-modal">
+          surface
+      </mwc-menu-surface>
 
       <mwc-card style="flex: 1; margin-left: 4px;">
         <div class="flex-scrollable-parent">
@@ -288,6 +309,7 @@ export class MarkdownNote extends ScopedElementsMixin(LitElement) {
       'syn-folks': SynFolks,
       'syn-commit-history': SynCommitHistory,
       'syn-context': SynContext,
+      'mwc-menu-surface': MenuSurface,
     };
   }
 

--- a/libs/ui/src/notes-service.ts
+++ b/libs/ui/src/notes-service.ts
@@ -1,6 +1,6 @@
 import { CellClient } from '@holochain-open-dev/cell-client';
 import { Dictionary, EntryHashB64 } from '@holochain-open-dev/core-types';
-import { Note, CreateNoteInput } from './types';
+import { CreateNoteInput, NoteContentsInput, UpdateNoteBacklinksInput, NoteWithBacklinks } from './types';
 
 export class NotesService {
   constructor(public cellClient: CellClient, public zomeName = 'notes') {}
@@ -9,8 +9,16 @@ export class NotesService {
     return this.callZome('create_new_note', input);
   }
 
-  async getAllNotes(): Promise<Dictionary<Note>> {
+  async getAllNotes(): Promise<Dictionary<NoteWithBacklinks>> {
     return this.callZome('get_all_notes', null);
+  }
+
+  async parseAndUpdateNoteLinks(input: NoteContentsInput): Promise<string[]> {
+    return this.callZome('parse_note_for_links_and_update_backlinks', input);
+  }
+
+  async updateNoteLinks(input: UpdateNoteBacklinksInput): Promise<null> {
+    return this.callZome('update_note_backlinks', input);
   }
 
   private callZome(fnName: string, payload: any) {

--- a/libs/ui/src/notes-store.ts
+++ b/libs/ui/src/notes-store.ts
@@ -22,14 +22,14 @@ import {
 } from '@holochain-syn/text-editor';
 
 import { NotesService } from './notes-service';
-import { Note } from './types';
+import { NoteWithBacklinks } from './types';
 
 export type NoteSynStore = SynStore<TextEditorGrammar>;
 
 export class NotesStore {
   service: NotesService;
 
-  #notesByEntryHash: Writable<Dictionary<Note>> = writable({});
+  #notesByEntryHash: Writable<Dictionary<NoteWithBacklinks>> = writable({});
 
   #openedNotes: Writable<Dictionary<NoteSynStore>> = writable({});
 
@@ -93,6 +93,7 @@ export class NotesStore {
         synDnaHash,
         timestamp,
         creator,
+        backlinks: {linksTo: {}, linkedFrom: {}},
       };
       return notes;
     });

--- a/libs/ui/src/types.ts
+++ b/libs/ui/src/types.ts
@@ -1,14 +1,34 @@
-import { AgentPubKeyB64, DnaHashB64 } from '@holochain-open-dev/core-types';
+import { AgentPubKeyB64, Dictionary, DnaHashB64, EntryHashB64 } from '@holochain-open-dev/core-types';
 
+interface NoteBacklinks {
+  linksTo: Dictionary<EntryHashB64>;
+  linkedFrom: Dictionary<EntryHashB64>;
+}
 export interface Note {
   title: string;
   creator: AgentPubKeyB64;
   timestamp: number;
   synDnaHash: DnaHashB64;
+  // backlinks?: NoteBacklinks;
 }
+
+export type NoteWithBacklinks = Note & {
+  backlinks: NoteBacklinks;
+}
+
 
 export interface CreateNoteInput {
   timestamp: number;
   title: string;
   synDnaHash: DnaHashB64;
+}
+
+export interface NoteContentsInput {
+  note: EntryHashB64;
+  contents: string;
+}
+
+export interface UpdateNoteBacklinksInput {
+  note: EntryHashB64;
+  linkTitles: string[];
 }

--- a/libs/zomes/notes/Cargo.toml
+++ b/libs/zomes/notes/Cargo.toml
@@ -11,6 +11,7 @@ name = "notes"
 chrono = {version = "0.4", features = ["serde"]}
 derive_more = "0"
 serde = "1"
+regex = "1"
 
 hdk = {version = "0.0.136", features = ["encoding"]}
 

--- a/libs/zomes/notes/src/lib.rs
+++ b/libs/zomes/notes/src/lib.rs
@@ -26,16 +26,30 @@ pub struct CreateNoteInput {
     pub timestamp: Timestamp,
     pub syn_dna_hash: DnaHashB64,
 }
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct NoteBacklinks {
+    pub links_to: BTreeMap<String, EntryHashB64>,
+    pub linked_from: BTreeMap<String, EntryHashB64>,
+}
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateNoteBacklinksInput {
+    pub note: EntryHashB64,
+    pub link_titles: Vec<String>,
+}
 
 #[hdk_extern]
 pub fn create_new_note(input: CreateNoteInput) -> ExternResult<EntryHashB64> {
     let creator = agent_info()?.agent_latest_pubkey;
 
+    // TODO: check if any other note links to this one, if it does, add it to backlink
+    // for now assume cannot start with backlinks
     let note = Note {
         creator: creator.into(),
         timestamp: input.timestamp,
         syn_dna_hash: input.syn_dna_hash,
-        title: input.title,
+        title: input.title.clone(),
     };
 
     create_entry(&note)?;
@@ -46,6 +60,12 @@ pub fn create_new_note(input: CreateNoteInput) -> ExternResult<EntryHashB64> {
 
     create_link(
         path.path_entry_hash()?,
+        hash.clone(),
+        HdkLinkType::Any,
+        (),
+    )?;
+    create_link(
+        title_path(input.title).path_entry_hash()?,
         hash.clone(),
         HdkLinkType::Any,
         (),
@@ -90,6 +110,100 @@ pub fn get_all_notes(_: ()) -> ExternResult<BTreeMap<EntryHashB64, Note>> {
     Ok(notes_map)
 }
 
+
+#[hdk_extern]
+pub fn update_note_backlinks(input: UpdateNoteBacklinksInput) -> ExternResult<()> {
+    // - figures out which links to delete, and which links to add  
+    // - gets all links of type `linksTo`, maps over all then, checking if the tag name matches the link names, if it doesn't delete (delete backlink as well)  
+    // - for each title in link_titles, check if matches a tag name, if not, create a new link
+    // - return the notes backlinks?
+    let links = get_links(EntryHash::from(input.note.clone()), None)?;
+    // find overlaps
+    for title in input.link_titles {
+        match links.iter().find(|link| link.clone().tag.eq(&links_to_tag(title.clone()))) {
+            // link exists
+            Some(_) => (),
+            // link doesn't exist, so create it
+            None => add_backlink(input.note.clone().into(), title)?,
+        }
+    }
+    Ok(())
+}
 fn all_notes_path() -> Path {
     Path::from("all_notes")
+}
+
+fn title_path(title: String) -> Path {
+    Path::from(title)
+}
+
+fn links_to_tag(title: String) -> LinkTag {
+    LinkTag::new(String::from(format!("links_to_{}", title)))
+}
+fn linked_from_tag(title: String) -> LinkTag {
+    LinkTag::new(String::from(format!("linked_from_{}", title)))
+}
+
+fn add_backlink(base_note: EntryHash, target_note_title: String) -> ExternResult<()> {
+    // get note by title
+    match get_note_by_title(target_note_title.clone())? {
+        Some(target_note) => {
+            let target_note_hash = hash_entry(target_note)?;
+            create_link(
+                base_note.clone(),
+                target_note_hash.clone(),
+                HdkLinkType::Any,
+                links_to_tag(target_note_title),
+            )?;
+            create_link(
+                target_note_hash,
+                base_note.clone(),
+                HdkLinkType::Any,
+                linked_from_tag(get_note(base_note)?.title),
+            )?;
+            ()
+        },
+        // note doesn't exist
+        None => (),
+    };
+    Ok(())
+}
+
+#[hdk_extern]
+pub fn get_note_by_title(title: String) -> ExternResult<Option<Note>> {
+    let mut links = get_links(
+        title_path(title).path_entry_hash()?,
+        None,
+    )?;
+    match links.pop() {
+        Some(link) => { 
+            match get::<EntryHash>(link.target.into(), GetOptions::default())? {
+                Some(element) => { 
+                    let note: Note = element.entry().to_app_option()?.ok_or(WasmError::Guest(String::from("Malformed note")))?;
+                    Ok(Some(note))
+                },
+                None => Ok(None),
+            }
+        },
+        None => Ok(None),
+    }
+}
+
+fn get_note(entry_hash: EntryHash) -> ExternResult<Note> {
+    match get(entry_hash, GetOptions::default())? {
+        Some(element) => {
+            let note: Note = element.entry().to_app_option()?.ok_or(WasmError::Guest(String::from("malformed note")))?;
+            Ok(note)
+        },
+        None => Err(WasmError::Guest(String::from("unable to resolve note from entry hash"))),
+    }
+}
+
+// pub fn get_note_links(note_hash: EntryHashB64) -> ExternResult<BTreeMap<String, EntryHashB64>> {
+#[hdk_extern]
+pub fn get_note_links(note_hash: EntryHashB64) -> ExternResult<Vec<Link>> {
+    get_links::<EntryHash>(
+        note_hash.into(),
+        None,
+    )
 }

--- a/libs/zomes/notes/src/lib.rs
+++ b/libs/zomes/notes/src/lib.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use hdk::prelude::holo_hash::*;
 use hdk::prelude::*;
+// use regex::Regex;
 
 #[hdk_entry(id = "note")]
 #[serde(rename_all = "camelCase")]
@@ -199,11 +200,26 @@ fn get_note(entry_hash: EntryHash) -> ExternResult<Note> {
     }
 }
 
-// pub fn get_note_links(note_hash: EntryHashB64) -> ExternResult<BTreeMap<String, EntryHashB64>> {
 #[hdk_extern]
-pub fn get_note_links(note_hash: EntryHashB64) -> ExternResult<Vec<Link>> {
-    get_links::<EntryHash>(
+pub fn get_note_links(note_hash: EntryHashB64) -> ExternResult<Vec<String>> {
+    // pub fn get_note_links(note_hash: EntryHashB64) -> ExternResult<BTreeMap<String, EntryHashB64>> {
+// pub fn get_note_links(note_hash: EntryHashB64) -> ExternResult<Vec<Link>> {
+    let links = get_links::<EntryHash>(
         note_hash.into(),
         None,
-    )
+    )?;
+    //     .collect::<ExternResult<Vec<(EntryHashB64, Note)>>>()?;
+
+    // let notes_map: BTreeMap<EntryHashB64, Note> = notes.into_iter().collect();
+    let links_tuple = links.iter().map(|link| title_from_tag(link.tag.clone()))
+        .collect::<ExternResult<Vec<String>>>()?;
+    Ok(links_tuple)
+}
+
+fn title_from_tag(link_tag: LinkTag) -> ExternResult<String> {
+    // let links_to_regex = Regex::new(r"links_to_(.*)$").map_err(|e| WasmError::Guest(String::from("error defining regex")))?;
+    // let linked_from_regex = Regex::new(r"linked_from_(.*)$").map_err(|_e| WasmError::Guest(String::from("error defining regex")))?;
+
+    let tag_string = String::from_utf8(link_tag.into_inner());
+    tag_string.map_err(|_e| WasmError::Guest(String::from("could not convert link tag to string")))
 }

--- a/libs/zomes/notes/tests/create_and_get.rs
+++ b/libs/zomes/notes/tests/create_and_get.rs
@@ -7,7 +7,7 @@ use hdk::prelude::Timestamp;
 use hdk::prelude::*;
 use holochain::test_utils::consistency_10s;
 use holochain::{conductor::config::ConductorConfig, sweettest::*};
-use notes::{CreateNoteInput, Note, UpdateNoteBacklinksInput};
+use notes::{CreateNoteInput, Note, UpdateNoteBacklinksInput, NoteBacklinks};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_and_get() {
@@ -84,15 +84,17 @@ async fn create_and_get() {
         .call(&alice_zome, "update_note_backlinks", non_existant_notes)
         .await;
 
-    let first_note_links: Vec<String> = conductors[0]
+    let first_note_links: NoteBacklinks = conductors[0]
         .call(&alice_zome, "get_note_links", first_note_hash.clone())
         .await;
-    let second_note_links: Vec<String> = conductors[0]
+    let second_note_links: NoteBacklinks = conductors[0]
         .call(&alice_zome, "get_note_links", second_note_hash.clone())
         .await;
 
-    assert_eq!(first_note_links.len(),1);
-    assert_eq!(first_note_links.clone().pop().unwrap(), format!("links_to_{}", note_title_2));
-    assert_eq!(second_note_links.len(),1);
-    assert_eq!(second_note_links.clone().pop().unwrap(), format!("linked_from_{}", note_title_1));
+    assert_eq!(first_note_links.links_to.len(), 1);
+    assert_eq!(first_note_links.links_to.keys().last().unwrap().clone(), note_title_2);
+    assert_eq!(first_note_links.links_to.values().last().unwrap().clone(), second_note_hash);
+    assert_eq!(second_note_links.linked_from.len(), 1);
+    assert_eq!(second_note_links.linked_from.keys().last().unwrap().clone(), note_title_1);
+    assert_eq!(second_note_links.linked_from.values().last().unwrap().clone(), first_note_hash);
 }

--- a/libs/zomes/notes/tests/create_and_get.rs
+++ b/libs/zomes/notes/tests/create_and_get.rs
@@ -110,7 +110,7 @@ async fn create_and_get() {
         contents: note_content,
     };
     let note_links_regexed: Vec<String> = conductors[0]
-        .call(&alice_zome, "parse_note_for_links_and_update_index", note_contents_input)
+        .call(&alice_zome, "parse_note_for_links_and_update_backlinks", note_contents_input)
         .await;
     assert_eq!(note_links_regexed.len(), 3);
     assert_eq!(note_links_regexed, note_links);

--- a/libs/zomes/notes/tests/create_and_get.rs
+++ b/libs/zomes/notes/tests/create_and_get.rs
@@ -84,15 +84,15 @@ async fn create_and_get() {
         .call(&alice_zome, "update_note_backlinks", non_existant_notes)
         .await;
 
-    let note_links: Vec<Link> = conductors[0]
+    let first_note_links: Vec<String> = conductors[0]
         .call(&alice_zome, "get_note_links", first_note_hash.clone())
         .await;
-    let linked_note_links: Vec<Link> = conductors[0]
+    let second_note_links: Vec<String> = conductors[0]
         .call(&alice_zome, "get_note_links", second_note_hash.clone())
         .await;
 
-    assert_eq!(note_links.len(),1);
-    assert_eq!(EntryHash::from(note_links.clone().pop().unwrap().target), EntryHash::from(second_note_hash));
-    assert_eq!(linked_note_links.len(),1);
-    assert_eq!(EntryHash::from(linked_note_links.clone().pop().unwrap().target), EntryHash::from(first_note_hash));
+    assert_eq!(first_note_links.len(),1);
+    assert_eq!(first_note_links.clone().pop().unwrap(), format!("links_to_{}", note_title_2));
+    assert_eq!(second_note_links.len(),1);
+    assert_eq!(second_note_links.clone().pop().unwrap(), format!("linked_from_{}", note_title_1));
 }

--- a/libs/zomes/notes/tests/create_and_get.rs
+++ b/libs/zomes/notes/tests/create_and_get.rs
@@ -7,7 +7,7 @@ use hdk::prelude::Timestamp;
 use hdk::prelude::*;
 use holochain::test_utils::consistency_10s;
 use holochain::{conductor::config::ConductorConfig, sweettest::*};
-use notes::{CreateNoteInput, Note};
+use notes::{CreateNoteInput, Note, UpdateNoteBacklinksInput};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_and_get() {
@@ -32,13 +32,14 @@ async fn create_and_get() {
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards");
 
+    let note_title_1 = String::from("new note");
     let create_note_input = CreateNoteInput {
-        title: String::from("new note"),
+        title: note_title_1.clone(),
         timestamp: Timestamp::from_micros(since_the_epoch.as_micros() as i64),
         syn_dna_hash: fixt!(DnaHashB64),
     };
 
-    let _note_hash: EntryHashB64 = conductors[0]
+    let first_note_hash: EntryHashB64 = conductors[0]
         .call(&alice_zome, "create_new_note", create_note_input)
         .await;
 
@@ -51,4 +52,47 @@ async fn create_and_get() {
 
     let note = all_notes.values().last().unwrap();
     assert_eq!(note.title, String::from("new note"));
+
+    let note_by_title: Option<Note> = conductors[1].call(&bob_zome, "get_note_by_title", note_title_1.clone()).await;
+    assert_eq!(note_by_title.unwrap().title, note_title_1.clone());
+
+    let note_title_2 = String::from("new note 2");
+    let create_note_input_2 = CreateNoteInput {
+        title: note_title_2.clone(),
+        timestamp: Timestamp::from_micros(since_the_epoch.as_micros() as i64),
+        syn_dna_hash: fixt!(DnaHashB64),
+    };
+
+    let second_note_hash: EntryHashB64 = conductors[0]
+        .call(&alice_zome, "create_new_note", create_note_input_2)
+        .await;
+
+    consistency_10s(&[&alice, &bobbo]).await;
+    let update_note_backlinks_input = UpdateNoteBacklinksInput {
+        note: first_note_hash.clone(),
+        link_titles: vec![String::from("new note 2")],
+    };
+    let non_existant_notes = UpdateNoteBacklinksInput {
+        note: first_note_hash.clone(),
+        link_titles: vec![String::from("blah")],
+    };
+    let _result: () = conductors[0]
+        .call(&alice_zome, "update_note_backlinks", update_note_backlinks_input)
+        .await;
+    // should not create a backlink since the note doesn't exist
+    let _result: () = conductors[0]
+        .call(&alice_zome, "update_note_backlinks", non_existant_notes)
+        .await;
+
+    let note_links: Vec<Link> = conductors[0]
+        .call(&alice_zome, "get_note_links", first_note_hash.clone())
+        .await;
+    let linked_note_links: Vec<Link> = conductors[0]
+        .call(&alice_zome, "get_note_links", second_note_hash.clone())
+        .await;
+
+    assert_eq!(note_links.len(),1);
+    assert_eq!(EntryHash::from(note_links.clone().pop().unwrap().target), EntryHash::from(second_note_hash));
+    assert_eq!(linked_note_links.len(),1);
+    assert_eq!(EntryHash::from(linked_note_links.clone().pop().unwrap().target), EntryHash::from(first_note_hash));
 }

--- a/libs/zomes/notes/tests/create_and_get.rs
+++ b/libs/zomes/notes/tests/create_and_get.rs
@@ -7,7 +7,7 @@ use hdk::prelude::Timestamp;
 use hdk::prelude::*;
 use holochain::test_utils::consistency_10s;
 use holochain::{conductor::config::ConductorConfig, sweettest::*};
-use notes::{CreateNoteInput, Note, UpdateNoteBacklinksInput, NoteBacklinks};
+use notes::{CreateNoteInput, Note, NoteWithBacklinks, UpdateNoteBacklinksInput, NoteBacklinks};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn create_and_get() {
@@ -45,7 +45,7 @@ async fn create_and_get() {
 
     consistency_10s(&[&alice, &bobbo]).await;
 
-    let all_notes: BTreeMap<EntryHashB64, Note> =
+    let all_notes: BTreeMap<EntryHashB64, NoteWithBacklinks> =
         conductors[1].call(&bob_zome, "get_all_notes", ()).await;
 
     assert_eq!(all_notes.keys().len(), 1);


### PR DESCRIPTION
notes can link to other using the `[[]]` syntax. Notes show a list of backlinks (notes that reference the existing note).

# todo

- [ ] complete modal popup when `[[]]` is typed, narrowing search when typing in between
- [ ] graph view
- [ ] update note backlinks more frequently (currently on when clicking end session)